### PR TITLE
global: prefill globals with the '__file__' constant

### DIFF
--- a/requirements_builder/requirements_builder.py
+++ b/requirements_builder/requirements_builder.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Requirements-Builder
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -89,7 +89,7 @@ def iter_requirements(level, extras, pip_file, setup_fp):
         result, requires, stuff = parse_pip_file(pip_file)
 
     with mock.patch.object(setuptools, 'setup') as mock_setup:
-        g = {}
+        g = {'__file__': setup_fp.name}
         exec(setup_fp.read(), g)
         assert g['setup']  # silence warning about unused imports
 

--- a/tests/data/setup.py
+++ b/tests/data/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Requirements-Builder
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -10,6 +10,10 @@
 """Build requirements files from setup.py requirements."""
 
 from setuptools import setup
+
+import os
+
+dirname = os.path.dirname(__file__)
 
 requirements = [
     'click>=5.0.0',


### PR DESCRIPTION
* Fix problem when the setup.py command plays with `__file__` to read,
  exec, or whatever.

Signed-off-by: Yoan Blanc <yoan@dosimple.ch>