### PR TITLE
global: add output option to the cli

### DIFF
--- a/requirements_builder/cli.py
+++ b/requirements_builder/cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Requirements-Builder
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -32,13 +32,20 @@ from .requirements_builder import iter_requirements
     '--req', '-r', default=None, help='Requirements file.',
     metavar='PATH', type=click.Path(
         exists=True, dir_okay=False, readable=True, resolve_path=True))
+@click.option(
+    '--output', '-o', default='-', help='Output file.',
+    type=click.File('w'))
 @click.argument(
     'setup', type=click.File('r'))
-def cli(level, extras, req, setup):
+def cli(level, extras, req, output, setup):
     """Calculate requirements for different purposes."""
     if level == 'dev' and not req:
         raise click.UsageError(
             "You must specify --req when using 'dev' level.")
     extras = set(extras)
-    for req in iter_requirements(level, extras, req, setup):
-        click.echo(req)
+
+    lines = ('{0}\n'.format(req) for req in iter_requirements(level,
+                                                              extras,
+                                                              req,
+                                                              setup))
+    output.writelines(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,3 +42,11 @@ def test_cli():
         assert result.output == \
             "-e git+https://github.com/mitsuhiko/click.git#egg=click\n" \
             "mock>=1.3.0\n"
+
+        result = runner.invoke(
+            cli, ['-l', 'min', '-o', 'requirements.txt', 'data/setup.py'])
+        assert result.exit_code == 0
+        assert result.output == ''
+        with open(join(getcwd(), 'requirements.txt')) as f:
+            assert f.read() == \
+                "click==5.0.0\nmock==1.3.0\n"

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35
 
 [testenv]
 setenv =


### PR DESCRIPTION
* The output option is useful in the tox context where one cannot
  redirect the output to a file.
  https://bitbucket.org/hpk42/tox/issues/73/pipe-output-of-command-into-file

Signed-off-by: Yoan Blanc <yoan@dosimple.ch>