### PR TITLE
cli: "extras" accepting comma separated values

### DIFF
--- a/requirements_builder/cli.py
+++ b/requirements_builder/cli.py
@@ -42,7 +42,7 @@ def cli(level, extras, req, output, setup):
     if level == 'dev' and not req:
         raise click.UsageError(
             "You must specify --req when using 'dev' level.")
-    extras = set(extras)
+    extras = set(req.strip() for extra in extras for req in extra.split(','))
 
     lines = ('{0}\n'.format(req) for req in iter_requirements(
         level, extras, req, setup

--- a/tests/data/setup.py
+++ b/tests/data/setup.py
@@ -22,8 +22,15 @@ requirements = [
     'mock>=1.3.0',
 ]
 
+extras_require = {
+    'docs': ['Sphinx>=1.4.2'],
+    'tests': ['pytest>=2.7'],
+    'flask': ['Flask>=0.11'],
+}
+
 setup(
     name='testpkh',
     version=testpkh.__version__,
     install_requires=requirements,
+    extras_require=extras_require,
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,21 +17,21 @@ from os.path import abspath, dirname, join
 from click.testing import CliRunner
 from requirements_builder.cli import cli
 
-DATA = abspath(join(dirname(__file__), "data/"))
+DATA = abspath(join(dirname(__file__), 'data/'))
 
 
 def test_cli():
     """Test cli."""
     runner = CliRunner()
     with runner.isolated_filesystem():
-        shutil.copytree(DATA, abspath(join(getcwd(), "data/")))
+        shutil.copytree(DATA, abspath(join(getcwd(), 'data/')))
         result = runner.invoke(cli, ['-l', 'min', 'data/setup.py'])
         assert result.exit_code == 0
-        assert result.output == "click==5.0.0\nmock==1.3.0\n"
+        assert result.output == 'click==5.0.0\nmock==1.3.0\n'
 
         result = runner.invoke(cli, ['-l', 'pypi', 'data/setup.py'])
         assert result.exit_code == 0
-        assert result.output == "click>=5.0.0\nmock>=1.3.0\n"
+        assert result.output == 'click>=5.0.0\nmock>=1.3.0\n'
 
         result = runner.invoke(cli, ['-l', 'dev', 'data/setup.py'])
         assert result.exit_code == 2
@@ -40,8 +40,8 @@ def test_cli():
             cli, ['-l', 'dev', '-r', 'data/req.txt', 'data/setup.py'])
         assert result.exit_code == 0
         assert result.output == \
-            "-e git+https://github.com/mitsuhiko/click.git#egg=click\n" \
-            "mock>=1.3.0\n"
+            '-e git+https://github.com/mitsuhiko/click.git#egg=click\n' \
+            'mock>=1.3.0\n'
 
         result = runner.invoke(
             cli, ['-l', 'min', '-o', 'requirements.txt', 'data/setup.py'])
@@ -49,4 +49,35 @@ def test_cli():
         assert result.output == ''
         with open(join(getcwd(), 'requirements.txt')) as f:
             assert f.read() == \
-                "click==5.0.0\nmock==1.3.0\n"
+                'click==5.0.0\nmock==1.3.0\n'
+
+
+def test_cli_extras():
+    """Test cli option extras."""
+    runner = CliRunner()
+    output = ['click==5.0.0', 'mock==1.3.0']
+    with runner.isolated_filesystem():
+        shutil.copytree(DATA, abspath(join(getcwd(), 'data/')))
+        result = runner.invoke(cli, [
+            '-l', 'min', '-e', 'docs', 'data/setup.py'
+        ])
+        assert result.exit_code == 0
+        assert set(result.output.split('\n')) == set(output + [
+            'Sphinx==1.4.2', ''
+        ])
+
+        result = runner.invoke(cli, [
+            '-l', 'min', '-e', 'docs, tests', 'data/setup.py'
+        ])
+        assert result.exit_code == 0
+        assert set(result.output.split('\n')) == set(output + [
+            'pytest==2.7', 'Sphinx==1.4.2', ''
+        ])
+
+        result = runner.invoke(cli, [
+            '-l', 'min', '-e', 'docs, tests', '-e', 'flask', 'data/setup.py'
+        ])
+        assert result.exit_code == 0
+        assert set(result.output.split('\n')) == set(output + [
+            'pytest==2.7', 'Sphinx==1.4.2', 'Flask==0.11', ''
+        ])


### PR DESCRIPTION
* FIX Makes `--extras` option accepting comma separated values as
  described in help.  (closes #14)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>

--
I'm looking for reviewers (ping @greut @lnielsen).