### PR TITLE
cli: accepting extra package from devel

### DIFF
--- a/requirements_builder/requirements_builder.py
+++ b/requirements_builder/requirements_builder.py
@@ -70,7 +70,7 @@ def parse_pip_file(path):
                     # another special command we don't recognize
                     stuff.append(line)
                 else:
-                    # ordenary requirement, similary to them used in setup.py
+                    # ordinary requirement, similarly to them used in setup.py
                     rnormal.append(line)
     except IOError:
         print(
@@ -98,14 +98,15 @@ def iter_requirements(level, extras, pip_file, setup_fp):
 
     # called arguments are in `mock_setup.call_args`
     mock_args, mock_kwargs = mock_setup.call_args
-    requires = mock_kwargs.get('install_requires', [])
+    install_requires = mock_kwargs.get('install_requires', [])
+    install_requires.extend(requires)
 
     requires_extras = mock_kwargs.get('extras_require', {})
     for e in extras:
         if e in requires_extras:
-            requires.extend(requires_extras[e])
+            install_requires.extend(requires_extras[e])
 
-    for pkg in pkg_resources.parse_requirements(requires):
+    for pkg in pkg_resources.parse_requirements(install_requires):
         # skip things we already know
         # FIXME be smarter about merging things
         if pkg.key in result:

--- a/tests/data/req.txt
+++ b/tests/data/req.txt
@@ -1,8 +1,9 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2017 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 
 -e git+https://github.com/mitsuhiko/click.git#egg=click
+Cython>=0.20

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Requirements-Builder
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2017 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
-
 
 """Tests for CLI module."""
 
@@ -41,6 +40,7 @@ def test_cli():
         assert result.exit_code == 0
         assert result.output == \
             '-e git+https://github.com/mitsuhiko/click.git#egg=click\n' \
+            'Cython>=0.20\n' \
             'mock>=1.3.0\n'
 
         result = runner.invoke(


### PR DESCRIPTION
Trying to install `lxml` from source: http://lxml.de/build.html requires Cython. But adding `Cython>=0.20` into `requirements-devel.txt` has no effect.

These changes should do the trick.