### PR TITLE
Python 2.6 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -14,6 +14,7 @@ python:
   - "3.4"
   - "3.3"
   - "2.7"
+  - "2.6"
   - "pypy"
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ sudo: false
 language: python
 
 python:
+  - "3.6"
   - "3.5"
   - "3.4"
   - "3.3"

--- a/requirements_builder/requirements_builder.py
+++ b/requirements_builder/requirements_builder.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -32,7 +32,7 @@ def parse_set(string):
 def minver_error(pkg_name):
     """Report error about missing minimum version constraint and exit."""
     print(
-        'ERROR: specify minimal version of "{}" using '
+        'ERROR: specify minimal version of "{0}" using '
         '">=" or "=="'.format(pkg_name),
         file=sys.stderr
     )
@@ -74,7 +74,7 @@ def parse_pip_file(path):
                     rnormal.append(line)
     except IOError:
         print(
-            'Warning: could not parse requirements file "{}"!',
+            'Warning: could not parse requirements file "{0}"!',
             file=sys.stderr
         )
 
@@ -116,18 +116,20 @@ def iter_requirements(level, extras, pip_file, setup_fp):
                 or (('<=' in specs) and ('<' in specs)):
             print(
                 'ERROR: Do not specify such weird constraints! '
-                '("{}")'.format(pkg),
+                '("{0}")'.format(pkg),
                 file=sys.stderr
             )
             sys.exit(1)
 
         if '==' in specs:
-            result[pkg.key] = '{}=={}'.format(
-                pkg.project_name, specs['=='])
+            result[pkg.key] = '{0}=={1}'.format(
+                pkg.project_name,
+                specs['==']
+            )
 
         elif '>=' in specs:
             if level == 'min':
-                result[pkg.key] = '{}=={}'.format(
+                result[pkg.key] = '{0}=={1}'.format(
                     pkg.project_name,
                     specs['>=']
                 )

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     tests_require=test_requirements,
     cmdclass={'test': PyTest},

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ from setuptools.command.test import test as TestCommand
 
 
 class PyTest(TestCommand):
-
     """Integration of PyTest with setuptools."""
 
     user_options = [('pytest-args=', 'a', 'Arguments to pass to py.test')]
@@ -53,7 +52,6 @@ with open(os.path.join('requirements_builder', 'version.py'), 'rt') as fp:
     exec(fp.read(), g)
     version = g['__version__']
 
-
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
@@ -78,7 +76,8 @@ test_requirements = [
 
 extras_requirements = {
     'docs': [
-        'Sphinx>=1.4.2',
+        'Sphinx<1.5.0,>=1.4.2',
+        'docutils<0.13,>=0.12'
     ],
     'tests': test_requirements,
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py26, py27, py33, py34, py35, py36
 
 [testenv]
 setenv =


### PR DESCRIPTION
Python 2.6 support depends on some `format` and `dependencies`.