### PR TITLE
release: v0.2.4 (upper requirements fix)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,14 @@
 Changes
 =======
 
+Version 0.2.4 (released 2017-03-10)
+-----------------------------------
+
+Bug fixes
+~~~~~~~~~
+
+- Fixes issue with upper version requirements being stripped from the output.
+
 Version 0.2.3 (released 2017-03-09)
 -----------------------------------
 

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 =============================
- Requirements-Builder v0.2.3
+ Requirements-Builder v0.2.4
 =============================
 
-Requirements-Builder v0.2.3 was released on March 9, 2017.
+Requirements-Builder v0.2.4 was released on March 10, 2017.
 
 About
 -----
@@ -12,13 +12,12 @@ Build requirements files from setup.py requirements.
 Bug fixes
 ---------
 
-- Fixes the issue with conditions on extra_require not being taken into
-  account.
+- Fixes issue with upper version requirements being stripped from the output.
 
 Installation
 ------------
 
-   $ pip install requirements-builder==0.2.3
+   $ pip install requirements-builder==0.2.4
 
 Documentation
 -------------

--- a/requirements_builder/requirements_builder.py
+++ b/requirements_builder/requirements_builder.py
@@ -117,11 +117,13 @@ def iter_requirements(level, extras, pip_file, setup_fp):
         # skip things we already know
         # FIXME be smarter about merging things
 
-        # Check for markers and skip if not applicable
-
-        if hasattr(pkg, 'marker') and pkg.marker is not None \
-                and not pkg.marker.evaluate():
-            continue
+        # Evaluate environment markers skip if not applicable
+        if hasattr(pkg, 'marker') and pkg.marker is not None:
+            if not pkg.marker.evaluate():
+                continue
+            else:
+                # Remove markers from the output
+                pkg.marker = None
 
         if pkg.key in result:
             continue
@@ -145,17 +147,13 @@ def iter_requirements(level, extras, pip_file, setup_fp):
                     pkg.project_name, specs['>=']
                 )
             else:
-                result[pkg.key] = '{0}>={1}'.format(
-                    pkg.project_name, specs['>=']
-                )
+                result[pkg.key] = pkg
 
         elif '>' in specs:
             if level == 'min':
                 minver_error(pkg.project_name)
             else:
-                result[pkg.key] = '{0}>{1}'.format(
-                    pkg.project_name, specs['>']
-                )
+                result[pkg.key] = pkg
 
         else:
             if level == 'min':

--- a/requirements_builder/version.py
+++ b/requirements_builder/version.py
@@ -16,4 +16,4 @@ This file is imported by ``requirements-builder.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/tests/data/setup.py
+++ b/tests/data/setup.py
@@ -19,6 +19,7 @@ dirname = os.path.dirname(__file__)
 requirements = [
     'click>=5.0.0',
     'mock>=1.3.0',
+    'CairoSVG<2.0.0,>=1.0.20',
     'functools32>=3.2.3-2; python_version=="2.7"',
 ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,23 +29,32 @@ def test_cli():
         assert result.exit_code == 0
         if sys.version_info[:2] == (2, 7):
             assert result.output == \
+                'CairoSVG==1.0.20\n' \
                 'click==5.0.0\n' \
                 'functools32==3.2.3-2\n' \
                 'ipaddr==2.1.11\n' \
                 'mock==1.3.0\n'
         else:
-            assert result.output == 'click==5.0.0\nmock==1.3.0\n'
+            assert result.output == \
+                'CairoSVG==1.0.20\n' \
+                'click==5.0.0\n' \
+                'mock==1.3.0\n'
 
         result = runner.invoke(cli, ['-l', 'pypi', 'data/setup.py'])
         assert result.exit_code == 0
 
         if sys.version_info[:2] == (2, 7):
-            assert result.output == 'click>=5.0.0\n' \
+            assert result.output == \
+                'CairoSVG<2.0.0,>=1.0.20\n' \
+                'click>=5.0.0\n' \
                 'functools32>=3.2.3-2\n' \
                 'ipaddr>=2.1.11\n' \
                 'mock>=1.3.0\n'
         else:
-            assert result.output == 'click>=5.0.0\nmock>=1.3.0\n'
+            assert result.output == \
+                'CairoSVG<2.0.0,>=1.0.20\n' \
+                'click>=5.0.0\n' \
+                'mock>=1.3.0\n'
 
         result = runner.invoke(cli, ['-l', 'dev', 'data/setup.py'])
         assert result.exit_code == 2
@@ -56,6 +65,7 @@ def test_cli():
         assert result.exit_code == 0
         if sys.version_info[:2] == (2, 7):
             assert result.output == \
+                'CairoSVG<2.0.0,>=1.0.20\n' \
                 '-e git+https://github.com/mitsuhiko/click.git#egg=click\n' \
                 'Cython>=0.20\n' \
                 'functools32>=3.2.3-2\n' \
@@ -63,6 +73,7 @@ def test_cli():
                 'mock>=1.3.0\n'
         else:
             assert result.output == \
+                'CairoSVG<2.0.0,>=1.0.20\n' \
                 '-e git+https://github.com/mitsuhiko/click.git#egg=click\n' \
                 'Cython>=0.20\n' \
                 'mock>=1.3.0\n'
@@ -75,19 +86,22 @@ def test_cli():
         with open(join(getcwd(), 'requirements.txt')) as f:
             if sys.version_info[:2] == (2, 7):
                 assert f.read() == \
+                    'CairoSVG==1.0.20\n' \
                     'click==5.0.0\n' \
                     'functools32==3.2.3-2\n' \
                     'ipaddr==2.1.11\n' \
                     'mock==1.3.0\n'
             else:
                 assert f.read() == \
-                    'click==5.0.0\nmock==1.3.0\n'
+                    'CairoSVG==1.0.20\n' \
+                    'click==5.0.0\n' \
+                    'mock==1.3.0\n'
 
 
 def test_cli_extras():
     """Test cli option extras."""
     runner = CliRunner()
-    output = ['click==5.0.0', 'mock==1.3.0']
+    output = ['CairoSVG==1.0.20', 'click==5.0.0', 'mock==1.3.0']
     if sys.version_info[:2] == (2, 7):
         output.append('functools32==3.2.3-2')
         output.append('ipaddr==2.1.11')


### PR DESCRIPTION
* Fixes issue with upper version requirements being stripped from the output (e.g. ``'CairoSVG<2.0.0,>=1.0.20'`` turning into ``'CairoSVG>=1.0.20'``.

* Adds test case with upper version requirement to catch same problem in the future.