### PR TITLE
cli: no setup.py if req.txt is provided.

### DIFF
--- a/requirements.lowest.txt
+++ b/requirements.lowest.txt
@@ -5,4 +5,4 @@
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 
-click==5.0.0
+click==6.1.0

--- a/requirements_builder/cli.py
+++ b/requirements_builder/cli.py
@@ -48,12 +48,17 @@ from .requirements_builder import iter_requirements
 @click.option(
     '--output', '-o', default='-', help='Output file.', type=click.File('w')
 )
-@click.argument('setup', type=click.File('r'))
-def cli(level, extras, req, output, setup):
+@click.argument('setup', type=click.File('r'), required=False)
+@click.pass_context
+def cli(ctx, level, extras, req, output, setup):
     """Calculate requirements for different purposes."""
     if level == 'dev' and not req:
         raise click.UsageError(
             "You must specify --req when using 'dev' level."
+        )
+    if not setup and not req:
+        raise click.MissingParameter(
+            ctx=ctx, param_hint='"setup"', param_type='argument'
         )
     extras = set(req.strip() for extra in extras for req in extra.split(','))
 

--- a/requirements_builder/requirements_builder.py
+++ b/requirements_builder/requirements_builder.py
@@ -61,8 +61,10 @@ def parse_pip_file(path):
                 elif line.startswith('-r'):
                     # recursive file command
                     splitted = re.split('-r\\s+', line)
-                    subrdev, subrnormal, substuff = parse_pip_file(splitted[1])
-                    for k, v in subrdev.iteritems():
+                    subrdev, subrnormal, substuff = parse_pip_file(
+                        os.path.join(os.path.dirname(path), splitted[1])
+                    )
+                    for k, v in subrdev.items():
                         if k not in rdev:
                             rdev[k] = v
                     rnormal.extend(subrnormal)
@@ -74,7 +76,7 @@ def parse_pip_file(path):
                     rnormal.append(line)
     except IOError:
         print(
-            'Warning: could not parse requirements file "{0}"!',
+            'Warning: could not parse requirements file "{0}"!'.format(path),
             file=sys.stderr
         )
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open('CHANGES.rst') as history_file:
     history = history_file.read().replace('.. :changes:', '')
 
 install_requires = [
-    'click>=5.0.0',
+    'click>=6.1.0',
     'mock>=1.3.0',
 ]
 

--- a/tests/data/other_req.txt
+++ b/tests/data/other_req.txt
@@ -1,9 +1,8 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2017 CERN.
+# Copyright (C) 2017 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 
--r other_req.txt
-Cython>=0.20
+-e git+https://github.com/mitsuhiko/click.git#egg=click

--- a/tests/data/setup.py
+++ b/tests/data/setup.py
@@ -27,9 +27,7 @@ extras_require = {
     'docs': ['Sphinx>=1.4.2'],
     'tests': ['pytest>=2.7'],
     'flask': ['Flask>=0.11'],
-    ':python_version=="2.7"': [
-        'ipaddr>=2.1.11'
-    ]
+    ':python_version=="2.7"': ['ipaddr>=2.1.11']
 }
 
 setup(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,15 +14,21 @@ import sys
 from os import getcwd
 from os.path import abspath, dirname, join
 
+import pytest
 from click.testing import CliRunner
 from requirements_builder.cli import cli
 
 DATA = abspath(join(dirname(__file__), 'data/'))
 
 
-def test_cli():
+@pytest.fixture
+def runner():
+    """Click test runner."""
+    return CliRunner()
+
+
+def test_cli(runner):
     """Test cli."""
-    runner = CliRunner()
     with runner.isolated_filesystem():
         shutil.copytree(DATA, abspath(join(getcwd(), 'data/')))
         result = runner.invoke(cli, ['-l', 'min', 'data/setup.py'])
@@ -98,9 +104,8 @@ def test_cli():
                     'mock==1.3.0\n'
 
 
-def test_cli_extras():
+def test_cli_extras(runner):
     """Test cli option extras."""
-    runner = CliRunner()
     output = ['CairoSVG==1.0.20', 'click==5.0.0', 'mock==1.3.0']
     if sys.version_info[:2] == (2, 7):
         output.append('functools32==3.2.3-2')
@@ -126,6 +131,32 @@ def test_cli_extras():
             ['-l', 'min', '-e', 'docs, tests', '-e', 'flask', 'data/setup.py']
         )
         assert result.exit_code == 0
-        assert set(result.output.split('\n')) == set(
-            output + ['pytest==2.7', 'Sphinx==1.4.2', 'Flask==0.11', '']
+        assert set(
+            result.output.split('\n')
+        ) == set(output + ['pytest==2.7', 'Sphinx==1.4.2', 'Flask==0.11', ''])
+
+
+def test_cli_no_setup(runner):
+    """Test cli with no setup.py provided."""
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ['-l', 'min'])
+
+        assert result.exit_code != 0
+        assert (
+            result.output.strip().split('\n')[-1] ==
+            'Error: Missing argument "setup".'
         )
+
+
+def test_cli_with_only_requirements(runner):
+    """Test cli with no setup.py provided but a req.txt"""
+    with runner.isolated_filesystem():
+        shutil.copytree(DATA, abspath(join(getcwd(), 'data/')))
+
+        result = runner.invoke(cli, ['-l', 'min', '-r', 'data/req.txt'])
+
+        assert result.exit_code == 0
+        assert set(result.output.strip().split('\n')) == set([
+            'Cython==0.20',
+            '-e git+https://github.com/mitsuhiko/click.git#egg=click'
+        ]), result.output.split('\n')

--- a/tests/test_requirements_builder.py
+++ b/tests/test_requirements_builder.py
@@ -27,12 +27,12 @@ def test_iter_requirements():
     # Min
     with open(SETUP) as f:
         assert list(iter_requirements("min", [], '', f)) == \
-            ['click==5.0.0', 'mock==1.3.0']
+            ['click==6.1.0', 'mock==1.3.0']
 
     # PyPI
     with open(SETUP) as f:
         assert list(iter_requirements("pypi", [], '', f)) == \
-            ['click>=5.0.0', 'mock>=1.3.0']
+            ['click>=6.1.0', 'mock>=1.3.0']
 
     # Dev
     with open(SETUP) as f:


### PR DESCRIPTION
I've encountered a case where there is no setup.py (shame, right?)

https://github.com/greut/chain-reaction/blob/master/tox.ini

Here is a quick fix to work around this use case, with tests and stuff.

Cheers,

PS: I had to upgrade click to 6.1 to reuse the `MissingParameter` exception.
PPS: extra feature, the recursive requirements.txt files were not properly tested, hence partially broken.