### PR TITLE
tox: remove Python 3.4 and 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@
 language: python
 
 python:
-  - "3.7-dev"
+  - "3.8-dev"
+  - "3.7"
   - "3.6"
   - "3.5"
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2016, 2017, 2018, 2019 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -8,7 +8,7 @@
 language: python
 
 python:
-  - "3.8-dev"
+  - "3.8"
   - "3.7"
   - "3.6"
   - "3.5"
@@ -51,5 +51,5 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    python: '2.7'
+    python: "3.7"
     condition: "$REQUIREMENTS = latest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ python:
   - "3.7"
   - "3.6"
   - "3.5"
-  - "2.7"
   - "pypy3"
-  - "pypy"
 
 env:
   - REQUIREMENTS=devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2016, 2017, 2018 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2019 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
-
-sudo: false
 
 language: python
 
@@ -13,7 +11,6 @@ python:
   - "3.7-dev"
   - "3.6"
   - "3.5"
-  - "3.4"
   - "2.7"
   - "pypy3"
   - "pypy"

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2016, 2017, 2018 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -43,8 +43,7 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        'Sphinx<2.3,>=1.8.5',
-        'docutils<0.14,>=0.13.1',
+        'Sphinx>=2.4',
     ],
     'tests': tests_require,
 }
@@ -84,5 +83,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        'Sphinx<1.5.0,>=1.4.2',
-        'docutils<0.13,>=0.12',
+        'Sphinx<2.3,>=1.8.5',
+        'docutils<0.14,>=0.13.1',
     ],
     'tests': tests_require,
 }
@@ -81,7 +81,6 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2016, 2017, 2018 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2019 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 [tox]
-envlist = pypy, py27, py34, py35, py36, py37
+envlist = pypy, py27, py35, py36, py37
+skip_missing_interpreters = true
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2016, 2017, 2018, 2019 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 [tox]
-envlist = pypy, py27, py35, py36, py37, py38
+envlist = pypy, pypy3, py27, py35, py36, py37, py38
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 [tox]
-envlist = pypy, py27, py35, py36, py37
+envlist = pypy, py27, py35, py36, py37, py38
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
The March 2019 release was the last one of 3.4, time to move on and play with Python 3.8.

superseeds #40, kudos to @cclauss for the initiative and help.
