### PR TITLE
feat: re-enable click on devel reqs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2021 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -29,8 +29,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-          python-version: [3.6, 3.7, 3.8]
-          requirements-level: [min, pypi]
+          python-version: [3.6, 3.7, 3.8, 3.9]
+          requirements-level: [min, pypi, dev]
 
     steps:
       - name: Checkout

--- a/requirements.devel.txt
+++ b/requirements.devel.txt
@@ -1,9 +1,8 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2018, 2020 CERN.
+# Copyright (C) 2015, 2018, 2020, 2021 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 
-# Latest click uses f-str, re-enable once 3.5 support is dropped by September 2020
-#-e git+https://github.com/pallets/click.git#egg=click
+-e git+https://github.com/pallets/click.git#egg=click

--- a/requirements_builder/requirements_builder.py
+++ b/requirements_builder/requirements_builder.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2016, 2017, 2018 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2021 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -15,14 +15,14 @@ import os
 import re
 import sys
 
+import mock
+import pkg_resources
+import setuptools
+
 try:
     import configparser
 except ImportError:  # pragma: no cover
     import ConfigParser as configparser
-
-import mock
-import pkg_resources
-import setuptools
 
 
 def parse_set(string):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2017, 2020 CERN.
+# Copyright (C) 2015, 2017, 2020, 2021 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -20,10 +20,10 @@ classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 packages = find:
@@ -39,6 +39,7 @@ setup_requires =
 tests_require =
     pytest-cache >= 1.0
     pytest-invenio >= 1.4.0
+    selenium <4 #; python_version==3.6
 
 [options.packages.find]
 include = requirements_builder

--- a/tests/test_requirements_builder.py
+++ b/tests/test_requirements_builder.py
@@ -63,4 +63,5 @@ def test_iter_requirements_cfg():
     with open(setup) as f:
         with open(setup_cfg) as g:
             assert list(iter_requirements("dev", [], req, f, g)) == \
-                ['click>=7.0', 'mock<4,>=1.3.0']
+                ['-e git+https://github.com/pallets/click.git#egg=click',
+                 'mock<4,>=1.3.0']

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 # This file is part of Requirements-Builder
-# Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 CERN.
 #
 # Requirements-Builder is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 [tox]
-envlist = pypy, pypy3, py27, py35, py36, py37, py38
+envlist = pypy, pypy3, py36, py37, py38, py39
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
requirements-builder doesn't support the `python_version` flag (yet). So it's there but commented out.