### PR TITLE
feat: add support PEP621 compatible pyproject.toml

### DIFF
--- a/requirements_builder/cli.py
+++ b/requirements_builder/cli.py
@@ -80,7 +80,14 @@ def cli(ctx, level, extras, req, output, setup):
     try:
         lines = (
             '{0}\n'.format(req)
-            for req in iter_requirements(level, extras, req, setup, setup_cfg, pyproject_toml_fp)
+            for req in iter_requirements(
+                level,
+                extras,
+                req,
+                setup,
+                setup_cfg,
+                pyproject_toml_fp
+            )
         )
         output.writelines(lines)
     finally:

--- a/requirements_builder/cli.py
+++ b/requirements_builder/cli.py
@@ -64,18 +64,23 @@ def cli(ctx, level, extras, req, output, setup):
         )
     extras = set(req.strip() for extra in extras for req in extra.split(','))
 
-    # figure out the setup.cfg file
+    # figure out the setup.cfg and pyproject.toml file
     setup_cfg = None
+    pyproject_toml_fp = None
 
     if setup:
         cfg = os.path.splitext(setup.name)[0] + ".cfg"
         if os.path.exists(cfg):
             setup_cfg = open(cfg, 'r')
 
+        toml_path = os.path.join(os.path.dirname(setup.name), "pyproject.toml")
+        if os.path.exists(toml_path):
+            pyproject_toml_fp = open(toml_path, 'rb')
+
     try:
         lines = (
             '{0}\n'.format(req)
-            for req in iter_requirements(level, extras, req, setup, setup_cfg)
+            for req in iter_requirements(level, extras, req, setup, setup_cfg, pyproject_toml_fp)
         )
         output.writelines(lines)
     finally:

--- a/requirements_builder/requirements_builder.py
+++ b/requirements_builder/requirements_builder.py
@@ -19,6 +19,12 @@ try:
     import configparser
 except ImportError:  # pragma: no cover
     import ConfigParser as configparser
+try:
+    import tomllib
+except ImportError:  # pragma: no cover
+    # python 3.10 and older
+    import tomli as tomllib
+
 
 import mock
 import pkg_resources
@@ -96,7 +102,7 @@ def parse_pip_file(path):
     return rdev, rnormal, stuff
 
 
-def iter_requirements(level, extras, pip_file, setup_fp, setup_cfg_fp=None):
+def iter_requirements(level, extras, pip_file, setup_fp, setup_cfg_fp=None, pyproject_toml_fp=None):
     """Iterate over requirements."""
     result = dict()
     requires = []
@@ -136,6 +142,17 @@ def iter_requirements(level, extras, pip_file, setup_fp, setup_cfg_fp=None):
             for name, value in parser.items("options.extras_require"):
                 requires_extras[name] = [s.strip()
                                          for s in value.strip().splitlines()]
+
+    if pyproject_toml_fp is not None:
+        toml_dict = tomllib.load(pyproject_toml_fp)
+        toml_project = toml_dict.get("project")
+        toml_requires = toml_project.get("dependencies")
+        if toml_requires is not None:
+            install_requires.extend(toml_requires)
+        optional_dependencies = toml_project.get("optional-dependencies")
+        if optional_dependencies is not None:
+            for name, value in optional_dependencies.items():
+                requires_extras[name] = value
 
     install_requires.extend(requires)
 

--- a/requirements_builder/requirements_builder.py
+++ b/requirements_builder/requirements_builder.py
@@ -102,7 +102,14 @@ def parse_pip_file(path):
     return rdev, rnormal, stuff
 
 
-def iter_requirements(level, extras, pip_file, setup_fp, setup_cfg_fp=None, pyproject_toml_fp=None):
+def iter_requirements(
+        level,
+        extras,
+        pip_file,
+        setup_fp,
+        setup_cfg_fp=None,
+        pyproject_toml_fp=None
+        ):
     """Iterate over requirements."""
     result = dict()
     requires = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ zip_safe = false
 install_requires =
     click >= 7.0
     mock <4,>= 1.3.0
+    tomli >= 2.0.0; python_version < '3.11'
 setup_requires =
     pytest-runner >= 2.6.2
     importlib-metadata >= 1.6.0

--- a/tests/fixtures/pyproject.toml
+++ b/tests/fixtures/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = [
+    "setuptools>=61.2",
+    "pytest-runner >= 2.6.2",
+    "importlib-metadata >= 1.6.0",
+    "mock >= 1.3.0",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "requirements-builder"
+version = "0.4.4dev"
+authors = [{name = "Invenio Collaboration", email = "info@inveniosoftware.org"}]
+description = "Build requirements files from setup.py requirements."
+readme = "README.rst"
+license = {text = "BSD"}
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+]
+dependencies = [
+    "click >= 7.0",
+    "mock <4,>= 1.3.0",
+    "tomli >= 2.0.0; python_version < '3.11'",
+]
+
+[project.urls]
+Homepage = "https://github.com/inveniosoftware/requirements-builder/"
+
+[project.optional-dependencies]
+docs = ["Sphinx >= 3"]
+all = [
+    "Sphinx >= 3",
+    "pytest-invenio >= 1.4.0",
+    "pytest-cache >= 1.0",
+]
+testing = [
+    "pytest-cache >= 1.0",
+    "pytest-invenio >= 1.4.0",
+]
+
+[project.scripts]
+requirements-builder = "requirements_builder.cli:cli"

--- a/tests/fixtures/setup_py_placeholder.txt
+++ b/tests/fixtures/setup_py_placeholder.txt
@@ -1,0 +1,6 @@
+# an empty placeholder setup.py fixture for use with tests 
+# that set dependencies in setup.cfg/pyproject.toml
+
+from setuptools import setup
+
+setup()

--- a/tests/test_requirements_builder.py
+++ b/tests/test_requirements_builder.py
@@ -9,12 +9,20 @@
 #
 """Tests for `requirements-builder` module."""
 
+import sys
 from os.path import abspath, dirname, join
 
 from requirements_builder import __version__, iter_requirements
 
 REQ = abspath(join(dirname(__file__), "./fixtures/requirements.devel.txt"))
 SETUP = abspath(join(dirname(__file__), "./fixtures/setup.txt"))
+
+
+def _has_toml_lib():
+    if sys.version_info.major == 3 and sys.version_info.minor < 11:
+        return False
+    else:
+        return True
 
 
 def test_version():
@@ -50,17 +58,80 @@ def test_iter_requirements_cfg():
     # Min
     with open(setup) as f:
         with open(setup_cfg) as g:
+            expected = ['click==7.0', 'mock==1.3.0']
+            if not _has_toml_lib():
+                expected.append("tomli==2.0.0")
             assert list(iter_requirements("min", [], '', f, g)) == \
-                ['click==7.0', 'mock==1.3.0']
+                expected
 
     # PyPI
     with open(setup) as f:
         with open(setup_cfg) as g:
+            expected = ['click>=7.0', 'mock<4,>=1.3.0']
+            if not _has_toml_lib():
+                expected.append("tomli>=2.0.0")
             assert list(iter_requirements("pypi", [], '', f, g)) == \
-                ['click>=7.0', 'mock<4,>=1.3.0']
+                expected
 
     # Dev
     with open(setup) as f:
         with open(setup_cfg) as g:
+            expected = ['click>=7.0', 'mock<4,>=1.3.0']
+            if not _has_toml_lib():
+                expected.append("tomli>=2.0.0")
             assert list(iter_requirements("dev", [], req, f, g)) == \
-                ['click>=7.0', 'mock<4,>=1.3.0']
+                expected
+
+
+def test_iter_requirements_toml():
+    """Test requirements-builder for
+    pyproject.toml (pep621)."""
+
+    setup_py = abspath(
+        join(dirname(__file__), "fixtures", "setup_py_placeholder.txt")
+        )
+    pyproject_toml = abspath(
+        join(dirname(__file__), "fixtures", "pyproject.toml")
+        )
+    req = abspath(join(dirname(__file__), "../requirements.devel.txt"))
+
+    # Min
+    with open(setup_py) as setup_py_fp:
+        with open(pyproject_toml, 'rb') as pyproject_toml_fp:
+            expected = ['click==7.0', 'mock==1.3.0']
+            if not _has_toml_lib():
+                expected.append("tomli==2.0.0")
+            assert list(iter_requirements(
+                    "min",
+                    [],
+                    '',
+                    setup_fp=setup_py_fp,
+                    pyproject_toml_fp=pyproject_toml_fp
+                    )) == expected
+    # # PyPI
+    with open(setup_py) as setup_py_fp:
+        with open(pyproject_toml, 'rb') as pyproject_toml_fp:
+            expected = ['click>=7.0', 'mock<4,>=1.3.0']
+            if not _has_toml_lib():
+                expected.append("tomli>=2.0.0")
+            assert list(iter_requirements(
+                    "pypi",
+                    [],
+                    '',
+                    setup_fp=setup_py_fp,
+                    pyproject_toml_fp=pyproject_toml_fp
+                    )) == expected
+
+    # Dev
+    with open(setup_py) as setup_py_fp:
+        with open(pyproject_toml, 'rb') as pyproject_toml_fp:
+            expected = ['click>=7.0', 'mock<4,>=1.3.0']
+            if not _has_toml_lib():
+                expected.append("tomli>=2.0.0")
+            assert list(iter_requirements(
+                    "dev",
+                    [],
+                    req,
+                    setup_fp=setup_py_fp,
+                    pyproject_toml_fp=pyproject_toml_fp
+                    )) == expected

--- a/tests/test_requirements_builder.py
+++ b/tests/test_requirements_builder.py
@@ -19,10 +19,8 @@ SETUP = abspath(join(dirname(__file__), "./fixtures/setup.txt"))
 
 
 def _has_toml_lib():
-    if sys.version_info.major == 3 and sys.version_info.minor < 11:
-        return False
-    else:
-        return True
+    # tomlib is part of the batteries included since 3.11
+    if sys.version_info >= (3, 11)
 
 
 def test_version():

--- a/tests/test_requirements_builder.py
+++ b/tests/test_requirements_builder.py
@@ -20,7 +20,7 @@ SETUP = abspath(join(dirname(__file__), "./fixtures/setup.txt"))
 
 def _has_toml_lib():
     # tomlib is part of the batteries included since 3.11
-    if sys.version_info >= (3, 11)
+    return sys.version_info >= (3, 11)
 
 
 def test_version():


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This adds support for extracting requirements from pyproject.toml as defined by [pep621](https://peps.python.org/pep-0621/)
Setuptools 61 added support for this and setuptools 65 has stabilized this. Supporting this also means that requirements-builder will be useful for non setuptools projects that uses pep621

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases. Tested to the same extend as setup.cfg
- [x] I've added relevant documentation. Neither setup.cfg nor pyproject.toml is explicitly documented not sure if we should change that.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code). **NA**
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code). **NA**
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code). **NA**
- [X] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions). I am the only contributer of the added code. Not sure if any changes to copyright headers are required. I do not need to be attributed.
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies). Added tomli dependency for parsing toml files on python <3.11

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

The architects team no longer exist (above link is a 404)

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
